### PR TITLE
Add option to have Animation

### DIFF
--- a/cfalertdialog/src/main/java/com/crowdfire/cfalertdialog/CFAlertDialog.java
+++ b/cfalertdialog/src/main/java/com/crowdfire/cfalertdialog/CFAlertDialog.java
@@ -49,6 +49,10 @@ import java.util.List;
 
 public class CFAlertDialog extends AppCompatDialog {
 
+    //region booleans
+    private boolean isStartAnimationSet;
+    private boolean isEndAnimaionSet;
+    
     // region Enums
 
     public enum CFAlertStyle {
@@ -270,9 +274,10 @@ public class CFAlertDialog extends AppCompatDialog {
     @Override
     public void show() {
         super.show();
-
+        if (isStartAnimationSet) { 
         // Perform the present animation
         startPresentAnimation();
+        }
     }
 
     @Override
@@ -281,8 +286,10 @@ public class CFAlertDialog extends AppCompatDialog {
         // Disable the view when being dismissed
         setEnabled(false);
 
+        if (isEndAnimationSet) {
         // perform the dismiss animation
         startDismissAnimation();
+        }
 
     }
 
@@ -887,7 +894,7 @@ public class CFAlertDialog extends AppCompatDialog {
     public static class Builder {
 
         private DialogParams params;
-
+       
         public Builder(Context context) {
             params = new DialogParams();
             this.params.context = context;
@@ -1061,6 +1068,15 @@ public class CFAlertDialog extends AppCompatDialog {
             return this;
         }
 
+        /**
+        Setup if Animatin in start or Stop needs
+        **/
+        public Builder isAnimatinStart(boolean start, boolean end) {
+            this.params.isStartAnimationSet = start;
+            this.params.isEndAnimaionSet = end;
+            return this;
+        }
+        
         public CFAlertDialog create() {
             CFAlertDialog cfAlertDialog;
             if (params.theme == 0) {


### PR DESCRIPTION
It is possible that one dose not want to have Animation Start or Animation End (dismiss) 'cause of LAGGING or sth like that 
/ boolean isStartAnimationSet and isEndAnimationSet added to have a more user-friend API

### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/Codigami/CFAlertDialog/blob/develop/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](https://github.com/Codigami/CFAlertDialog/blob/develop/README.md)
* [ ] I have searched for a similar pull request in the [project](https://github.com/Codigami/CFAlertDialog/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...
